### PR TITLE
Fix blank page by setting Vite base and CSS import order

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,8 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap');
 
 body {
   font-family: 'Inter', sans-serif;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // Use relative paths for assets so the site works when
+  // deployed from a subdirectory (e.g., GitHub Pages).
+  base: './',
   plugins: [react()],
   optimizeDeps: {
     exclude: ['lucide-react'],


### PR DESCRIPTION
## Summary
- load Google Fonts before Tailwind directives in index.css
- set Vite `base` to relative path so assets resolve when deployed from a subdirectory

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689860a8b9f88327bb4e5cc8d0f0f235